### PR TITLE
Turn off all background refresh notifications

### DIFF
--- a/AltStore/Managing Apps/AppManager.swift
+++ b/AltStore/Managing Apps/AppManager.swift
@@ -758,7 +758,7 @@ extension AppManager
 extension AppManager
 {
     @discardableResult
-    func backgroundRefresh(_ installedApps: [InstalledApp], presentsNotifications: Bool = true, completionHandler: @escaping (Result<[String: Result<InstalledApp, Error>], Error>) -> Void) -> BackgroundRefreshAppsOperation
+    func backgroundRefresh(_ installedApps: [InstalledApp], presentsNotifications: Bool = false, completionHandler: @escaping (Result<[String: Result<InstalledApp, Error>], Error>) -> Void) -> BackgroundRefreshAppsOperation
     {
         let backgroundRefreshAppsOperation = BackgroundRefreshAppsOperation(installedApps: installedApps)
         backgroundRefreshAppsOperation.resultHandler = completionHandler

--- a/AltStore/Operations/BackgroundRefreshAppsOperation.swift
+++ b/AltStore/Operations/BackgroundRefreshAppsOperation.swift
@@ -56,7 +56,7 @@ class BackgroundRefreshAppsOperation: ResultOperation<[String: Result<InstalledA
     let installedApps: [InstalledApp]
     private let managedObjectContext: NSManagedObjectContext
     
-    var presentsFinishedNotification: Bool = true
+    var presentsFinishedNotification: Bool = false
     
     private let refreshIdentifier: String = UUID().uuidString
     private var runningApplications: Set<String> = []
@@ -189,12 +189,12 @@ private extension BackgroundRefreshAppsOperation
             
             let content = UNMutableNotificationContent()
             
-            var shouldPresentAlert = true
+            var shouldPresentAlert = false
             
             do
             {
                 let results = try result.get()
-                shouldPresentAlert = !results.isEmpty
+                shouldPresentAlert = false
                 
                 for (_, result) in results
                 {
@@ -216,7 +216,7 @@ private extension BackgroundRefreshAppsOperation
                 content.title = NSLocalizedString("Failed to Refresh Apps", comment: "")
                 content.body = error.localizedDescription
                 
-                shouldPresentAlert = true
+                shouldPresentAlert = false
             }
             
             if shouldPresentAlert


### PR DESCRIPTION
This removes all background refresh notifications but keeps the "Reminder to open SideStore every so often", and the "x app expires soon" local push notifications.